### PR TITLE
feature:embed-social-media-content wit twitter summary card Finishes …

### DIFF
--- a/imports/plugins/included/social/client/components/twitter.js
+++ b/imports/plugins/included/social/client/components/twitter.js
@@ -12,11 +12,11 @@ export function getTwitterMeta(props) {
   const description = props.settings.description;
 
   const meta = [
-    { property: "twitter:card", content: "summary" },
-    { property: "twitter:creator", content: username },
-    { property: "twitter:url", content: url },
-    { property: "twitter:title", content: title },
-    { property: "twitter:description", content: description }
+    { name: "twitter:card", content: "summary" },
+    { name: "twitter:creator", content: username },
+    { name: "twitter:url", content: url },
+    { name: "twitter:title", content: title },
+    { name: "twitter:description", content: description }
   ];
 
   if (props.media) {
@@ -31,6 +31,7 @@ export function getTwitterMeta(props) {
       content: media
     });
   }
+  return meta;
 }
 
 class TwitterSocialButton extends Component {

--- a/imports/plugins/included/social/client/components/twitter.js
+++ b/imports/plugins/included/social/client/components/twitter.js
@@ -14,6 +14,7 @@ export function getTwitterMeta(props) {
   const meta = [
     { name: "twitter:card", content: "summary" },
     { name: "twitter:creator", content: username },
+    { name: "twitter:site", content: username },
     { name: "twitter:url", content: url },
     { name: "twitter:title", content: title },
     { name: "twitter:description", content: description }


### PR DESCRIPTION
…#145839115


- [ ] This PR adds twitter summary card to content while sharing on twitter
- [ ] To test, open a product an click on twitter social icon, though it depends on time twitter approves the URL

